### PR TITLE
添加自定义文件类型及数据源支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@
 
 ## 使用方法
 
-- 在项目根目录建立data文件夹。将训练语料以train.json为名放入data目录中。train.json里是一个json列表，列表的每个元素都分别是一篇要训练的文章。
+- 在项目根目录建立data文件夹。将训练语料以train.json为名放入data目录中。train.json里是一个json列表，列表的每个元素都分别是一篇要训练的文章。可以自定义文件类型，包括txt，csv，datasources(db)。
 - 运行train.py文件，勾选 --raw ，会自动预处理数据。
-- 预处理完成之后，直接运行train.py文件，即可开始训练。
+- 预处理完成之后，会自动执行训练。
 
+### 自定义文件类型或数据源
+1. 修改pre_process_data.py文件中的is_default_file_type()方法，返回值更改为False。
+2. 覆写pre_process_data.py文件中的load()方法，具体示例看文件已注释的方法。
 ## 文件结构
 
 - generate.py 与 train.py 分别是生成与训练的脚本。

--- a/pre_process_data.py
+++ b/pre_process_data.py
@@ -1,0 +1,22 @@
+DEFAULT_FILE_TYPE = ".json"
+
+# 默认采用json文件作为输入的文件类型
+# 如果自定义了文件类型，或者数据源，请return False
+def is_default_file_type():
+  return True
+
+# 示例方法
+# def load():
+#     #根据文件编码类型，选择相应编码
+#     with open("/user/npl/gpt/data/train.txt", 'r', encoding='gbk') as f:
+#       print('reading lines')
+#       #如果文件编码是GBK，才进行转换，否则lines = f.readlines()
+#       lines = f.readlines();
+#       lines = [line.replace('\n', ' [SEP] ') for line in lines]  # 用[SEP]表示换行, 段落之间使用SEP表示段落结束
+#     return lines
+
+# 请用相应的原编码加载文件
+# 自定文件类型或者数据源必须实现此方法
+# 最终返回列表，具体参考上面示例
+def load():
+ pass

--- a/train.py
+++ b/train.py
@@ -10,16 +10,23 @@ from datetime import datetime
 from tqdm import tqdm
 from torch.nn import DataParallel
 from tokenizations.bpe_tokenizer import get_encoder
+import pre_process_data as ppd
 
 
 def build_files(data_path, tokenized_data_path, num_pieces, full_tokenizer, min_length):
+    if ppd.is_default_file_type(): #是否采用默认json类型，默认编码为utf-8
+      if ppd.DEFAULT_FILE_TYPE in data_path:
+        with open(data_path, 'r', encoding='utf8') as f:
+          print('reading lines')
+          lines = json.load(f)
+          lines = [line.replace('\n', ' [SEP] ') for line in lines]  # 用[SEP]表示换行, 段落之间使用SEP表示段落结束
+      else:
+        raise Exception("请使用json文件类型，或者自定义文件类型，请看pre_process_data.py文件load方法")
+    else: #自定义数据源的，调用pre_process_data.py中的load方法
+      lines= ppd.load()
+    all_len = len(lines)
     if not os.path.exists(tokenized_data_path):
         os.mkdir(tokenized_data_path)
-    with open(data_path, 'r', encoding='utf8') as f:
-        print('reading lines')
-        lines = json.load(f)
-        lines = [line.replace('\n', ' [SEP] ') for line in lines]  # 用[SEP]表示换行, 段落之间使用SEP表示段落结束
-        all_len = len(lines)
     for i in tqdm(range(num_pieces)):
         sublines = lines[all_len // num_pieces * i: all_len // num_pieces * (i + 1)]
         if i == num_pieces - 1:

--- a/train_single.py
+++ b/train_single.py
@@ -15,22 +15,29 @@ from tqdm import tqdm
 
 
 def build_files(raw_data_path, tokenized_data_path, full_tokenizer, num_pieces):
+    if ppd.is_default_file_type(): #是否采用默认json类型，默认编码为utf-8
+      if ppd.DEFAULT_FILE_TYPE in data_path:
+        with open(data_path, 'r', encoding='utf8') as f:
+          print('reading lines')
+          lines = json.load(f)
+          lines = [line.replace('\n', ' [SEP] ') for line in lines]  # 用[SEP]表示换行, 段落之间使用SEP表示段落结束
+      else:
+        raise Exception("请使用json文件类型，或者自定义文件类型，请看pre_process_data.py文件load方法")
+    else: #自定义数据源的，调用pre_process_data.py中的load方法
+      lines= ppd.load()
+      all_len = len(lines)
+    single = ''.join(lines)
+    len_single = len(single)
     if not os.path.exists(tokenized_data_path):
         os.mkdir(tokenized_data_path)
-    with open(raw_data_path, 'r', encoding='utf8') as f:
-        print('reading lines')
-        lines = json.load(f)
-        lines = [line.replace('\n', ' [SEP] ') for line in lines]  # 用[SEP]表示换行
-        single = ''.join(lines)
-        len_single = len(single)
-        for i in tqdm(range(num_pieces)):
-            single_ids = full_tokenizer.convert_tokens_to_ids(
-                full_tokenizer.tokenize(single[len_single // num_pieces * i: len_single // num_pieces * (i + 1)]))
-            with open(tokenized_data_path + 'tokenized_train_{}.txt'.format(i), 'w') as f:
-                for id in single_ids[:-1]:
-                    f.write(str(id) + ' ')
-                f.write(str(single_ids[-1]))
-                f.write('\n')
+    for i in tqdm(range(num_pieces)):
+        single_ids = full_tokenizer.convert_tokens_to_ids(
+            full_tokenizer.tokenize(single[len_single // num_pieces * i: len_single // num_pieces * (i + 1)]))
+        with open(tokenized_data_path + 'tokenized_train_{}.txt'.format(i), 'w') as f:
+            for id in single_ids[:-1]:
+                f.write(str(id) + ' ')
+            f.write(str(single_ids[-1]))
+            f.write('\n')
 
     print('finish')
 

--- a/train_single.py
+++ b/train_single.py
@@ -8,6 +8,7 @@ import numpy as np
 from datetime import datetime
 from torch.nn import DataParallel
 from tqdm import tqdm
+import pre_process_data as ppd
 
 '''
 如果训练材料是全部堆在一起不分篇章的话用这个文件


### PR DESCRIPTION
您好！
默认只允许加载Json文件类型，但是大家的数据存在的形式可能不同，有可能是TXT、CSV、DataSource(DB)，或者其它。所以添加了一个pre_process_data.py文件，在里面添加了两个方法：
1 is_default_file_type 声明是否采用默认的Json格式文件，或自定义
2 load 方法实现自定义加载，可以根据实际需求，读取CSV，TXT，DataSource数据，当然需要自己去实现，最终的返回值依旧是list。
最后，修改了train.py及train_single.py文件的build_files方法，只是更改了极少代码，您可以看一下。如果采用原先的Json加载，不会有任何的影响。
自定义文件类型与数据源，也方便以后，如果有朋友想添加一些示例，但数据又不方便公开，使用这样的数据加载方式，大家可以利用自己手上已有的数据来运行实例。
谢谢！