### PR TITLE
support newer transformers package

### DIFF
--- a/train_single.py
+++ b/train_single.py
@@ -8,6 +8,7 @@ import numpy as np
 from datetime import datetime
 from torch.nn import DataParallel
 from tqdm import tqdm
+from packaging import version
 
 '''
 如果训练材料是全部堆在一起不分篇章的话用这个文件
@@ -116,8 +117,13 @@ def main():
     print('total steps = {}'.format(total_steps))
 
     optimizer = transformers.AdamW(model.parameters(), lr=lr, correct_bias=True)
-    scheduler = transformers.WarmupLinearSchedule(optimizer, warmup_steps=warmup_steps,
+    if version.parse(transformers.__version__) <= version.parse("2.1.1"):
+        scheduler = transformers.WarmupLinearSchedule(optimizer, warmup_steps=warmup_steps,
                                                           t_total=total_steps)
+    else:
+        scheduler = transformers.get_linear_schedule_with_warmup(optimizer, num_warmup_steps=warmup_steps,
+                                                          num_training_steps=total_steps)
+
     if fp16:
         try:
             from apex import amp


### PR DESCRIPTION
I find that GPT2-chinese raises ImportError: cannot import name 'WarmupLinearSchedule', if transformers version is greater than 2.1.1. So I used new api 'get_linear_schedule_with_warmup' instead of 'WarmupLinearSchedule' and attached these changes here.