### PR TITLE
修改部分代码适配新版transformers

### DIFF
--- a/train.py
+++ b/train.py
@@ -78,7 +78,7 @@ def main():
 
     os.environ["CUDA_VISIBLE_DEVICES"] = args.device  # 此处设置程序使用哪些显卡
 
-    model_config = transformers.modeling_gpt2.GPT2Config.from_json_file(args.model_config)
+    model_config = transformers.models.gpt2.modeling_gpt2.GPT2Config.from_json_file(args.model_config)
     print('config:\n' + model_config.to_json_string())
 
     n_ctx = model_config.n_ctx
@@ -119,9 +119,9 @@ def main():
         print('files built')
 
     if not args.pretrained_model:
-        model = transformers.modeling_gpt2.GPT2LMHeadModel(config=model_config)
+        model = transformers.models.gpt2.modeling_gpt2.GPT2LMHeadModel(config=model_config)
     else:
-        model = transformers.modeling_gpt2.GPT2LMHeadModel.from_pretrained(args.pretrained_model)
+        model = transformers.models.gpt2.modeling_gpt2.GPT2LMHeadModel.from_pretrained(args.pretrained_model)
     model.train()
     model.to(device)
 


### PR DESCRIPTION
现在新版transformers的modeling_gpt2已经移至transformers.models.gpt2中，在此作出修改以应对变更