### PR TITLE
实验发现梯度归一化语句应该放在with外

### DIFF
--- a/train.py
+++ b/train.py
@@ -201,7 +201,7 @@ def main():
                 if fp16:
                     with amp.scale_loss(loss, optimizer) as scaled_loss:
                         scaled_loss.backward()
-                        torch.nn.utils.clip_grad_norm_(amp.master_params(optimizer), max_grad_norm)
+                    torch.nn.utils.clip_grad_norm_(amp.master_params(optimizer), max_grad_norm)
                 else:
                     loss.backward()
                     torch.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm)

--- a/train_single.py
+++ b/train_single.py
@@ -179,7 +179,7 @@ def main():
                 if fp16:
                     with amp.scale_loss(loss, optimizer) as scaled_loss:
                         scaled_loss.backward()
-                        torch.nn.utils.clip_grad_norm_(amp.master_params(optimizer), max_grad_norm)
+                    torch.nn.utils.clip_grad_norm_(amp.master_params(optimizer), max_grad_norm)
                 else:
                     loss.backward()
                     torch.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm)


### PR DESCRIPTION
在fp16+hvd训练中,发现存在精度下溢的情况.浏览代码后,高度怀疑以下代码块.
```python
if fp16:
  with amp.scale_loss(loss, optimizer) as scaled_loss:
    scaled_loss.backward()
    torch.nn.utils.clip_grad_norm_(amp.master_params(optimizer), max_grad_norm)
```

查看[官方文档](https://nvidia.github.io/apex/advanced.html),发现梯度归一化语句应该放在with外.

![image](https://user-images.githubusercontent.com/60613238/158851792-e39995c2-c234-41c1-b8b4-f4f5800031d4.png)

问题解决.

![image](https://user-images.githubusercontent.com/60613238/158852424-e4b24fca-114c-43d3-8e3d-ce92d61c01c2.png)

感谢作者,我在paper的致谢部分特别鸣谢了这个repo.等paper发布后我会上传我的分布式训练代码,包括8种不同的HPC训练方式.