### PR TITLE
fix: ensure that the entire directory path is created; refactor: don't use same variable name in the parent loop;

### DIFF
--- a/generate_texts.py
+++ b/generate_texts.py
@@ -164,15 +164,15 @@ def main():
                 generated += 1
                 text = tokenizer.convert_ids_to_tokens(out)
 
-                for i, item in enumerate(text[:-1]):  # 确保英文前后有空格
+                for idx, item in enumerate(text[:-1]):  # 确保英文前后有空格
                     if is_word(item) and is_word(text[i + 1]):
-                        text[i] = item + ' '
+                        text[idx] = item + ' '
 
-                for i, item in enumerate(text):
+                for idx, item in enumerate(text):
                     if item == '[MASK]':
-                        text[i] = ''
+                        text[idx] = ''
                     if item == '[CLS]' or item == '[SEP]':
-                        text[i] = '\n'
+                        text[idx] = '\n'
 
                 print("=" * 40 + " SAMPLE " + str(generated) + " " + "=" * 40)
                 text = ''.join(text).replace('##', '').strip()

--- a/train_single.py
+++ b/train_single.py
@@ -22,7 +22,7 @@ def build_files(raw_data_path, tokenized_data_path, full_tokenizer, num_pieces):
     single = ''.join(lines)
     len_single = len(single)
     if not os.path.exists(tokenized_data_path):
-        os.mkdir(tokenized_data_path)
+        os.makedirs(tokenized_data_path, exist_ok=True)
     for i in tqdm(range(num_pieces)):
         single_ids = full_tokenizer.convert_tokens_to_ids(
             full_tokenizer.tokenize(single[len_single // num_pieces * i: len_single // num_pieces * (i + 1)]))


### PR DESCRIPTION
Using os.mkdir to create a directory can lead to an error if the parent directory does not exist. It's safer to use os.makedirs with the exist_ok=True parameter to ensure that the entire directory path is created if it does not exist.
The original line uses os.mkdir which can fail if the directory's parent does not exist. Changing it to os.makedirs and adding the exist_ok=True parameter ensures that the directory is created along with any necessary parent directories, preventing potential runtime errors.